### PR TITLE
Bringing initial if/else check inline with runtime

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -14,9 +14,11 @@ if !exists("main_syntax")
   if version < 600
     syntax clear
   elseif exists("b:current_syntax")
-  finish
-endif
+    finish
+  endif
   let main_syntax = 'css'
+elseif exists("b:current_syntax") && b:current_syntax == "css"
+  finish
 endif
 
 let s:cpo_save = &cpo


### PR DESCRIPTION
I submitted a patch for Vim 7.4 a while back that modified the initial
if/else syntax check at the beginning to prevent the default CSS file
from clobbering plugin CSS syntaxes.

Since this repo seems to be the one used as the default runtime for vim,
I am syncing up the initial checks just to prevent an accidental
regression.
