### PR TITLE
CSS Function Optimization

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -163,11 +163,13 @@ syn match cssColor contained "\<white\>"
 syn match cssColor contained "#[0-9A-Fa-f]\{3\}\>" contains=cssUnitDecorators
 syn match cssColor contained "#[0-9A-Fa-f]\{6\}\>" contains=cssUnitDecorators
 
-syn region cssURL contained matchgroup=cssFunctionName start="\<url\s*(" end=")" oneline keepend
-syn region cssFunction contained matchgroup=cssFunctionName start="\<\(rgb\|clip\|attr\|counter\|rect\|cubic-bezier\)\s*(" end=")" oneline keepend
-syn region cssFunction contained matchgroup=cssFunctionName start="\<\(rgba\|hsl\|hsla\)\s*(" end=")" oneline keepend
-syn region cssFunction contained matchgroup=cssFunctionName start="\<\(linear\|radial\)-gradient\s*(" end=")" oneline keepend
-syn region cssFunction contained matchgroup=cssFunctionName start="\<\(matrix\(3d\)\=\|scale\(3d\|X\|Y\|Z\)\=\|translate\(3d\|X\|Y\|Z\)\=\|skew\(X\|Y\)\=\|rotate\(3d\|X\|Y\|Z\)\=\|perspective\)\s*(" end=")" oneline keepend
+syn region cssURL contained matchgroup=cssFunctionName start="\<url\s*(" end=")" oneline
+syn region cssFunction contained matchgroup=cssFunctionName start="\<\(rgb\|clip\|attr\|counter\|rect\|cubic-bezier\)\s*(" end=")" oneline  contains=cssValueInteger,cssValueNumber,cssValueLength,cssFunctionComma
+syn region cssFunction contained matchgroup=cssFunctionName start="\<\(rgba\|hsl\|hsla\|color-stop\)\s*(" end=")" oneline  contains=cssColor,cssValueInteger,cssValueNumber,cssValueLength,cssFunctionComma,cssFunction
+syn region cssFunction contained matchgroup=cssFunctionName start="\<\(linear-\|radial-\)\=\gradient\s*(" end=")" oneline  contains=cssColor,cssValueInteger,cssValueNumber,cssValueLength,cssFunction,cssGradientAttr,cssFunctionComma
+syn region cssFunction contained matchgroup=cssFunctionName start="\<\(matrix\(3d\)\=\|scale\(3d\|X\|Y\|Z\)\=\|translate\(3d\|X\|Y\|Z\)\=\|skew\(X\|Y\)\=\|rotate\(3d\|X\|Y\|Z\)\=\|perspective\)\s*(" end=")" oneline contains=cssValueInteger,cssValueNumber,cssValueLength,cssValueAngle,cssFunctionComma
+syn keyword cssGradientAttr contained top bottom left right cover center middle ellipse at
+syn match cssFunctionComma contained ","
 
 " Prop and Attr
 syn keyword cssCommonAttr contained auto none inherit all default normal
@@ -482,6 +484,7 @@ if version >= 508 || !exists("did_css_syn_inits")
   HiLink cssPaddingAttr cssAttr
   HiLink cssPagedMediaAttr cssAttr
   HiLink cssPositioningAttr cssAttr
+  HiLink cssGradientAttr cssAttr
   HiLink cssPrintAttr cssAttr
   HiLink cssRubyAttr cssAttr
   HiLink cssSpeechAttr cssAttr
@@ -505,6 +508,7 @@ if version >= 508 || !exists("did_css_syn_inits")
   HiLink cssFunction Constant
   HiLink cssURL String
   HiLink cssFunctionName Function
+  HiLink cssFunctionComma Function
   HiLink cssColor Constant
   HiLink cssIdentifier Function
   HiLink cssInclude Include


### PR DESCRIPTION
This commit adds support for the units contained with css functions, such
as gradients, rgb, translate, etc.

I also improved detection of the gradient function.

See attached screenshot

![example](https://f.cloud.github.com/assets/83376/891399/33ac763c-fa57-11e2-9a83-54671d1638da.png)
