### PR TITLE
Fixed background-size when used with vendor prefix

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -188,7 +188,7 @@ syn match cssAnimationAttr contained "\<ease\(-\(in-out\|out\|in\)\)\=\>"
 syn match cssAnimationAttr contained "\<content\(-box\)\=\>"
 syn match cssAnimationAttr contained "\<border-box\>"
 
-syn match cssBackgroundProp contained "\<background\(-\(color\|image\|repeat\|attachment\|position\|clip\|origin\|size\)\)\=\>"
+syn match cssBackgroundProp contained "background\(-\(color\|image\|repeat\|attachment\|position\|clip\|origin\|size\)\)\="
 syn keyword cssBackgroundAttr contained fixed over contain
 syn match cssBackgroundAttr contained "\<no-repeat\>"
 syn match cssBackgroundAttr contained "\<repeat\(-[xy]\)\=\>"


### PR DESCRIPTION
Vendor prefixes would cause the detection of background-size (and most
likely any other background-x combination).

This should fix that.
