### PR TITLE
Fix for data encoded image within cssURL

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -167,7 +167,7 @@ syn match cssColor contained "\<white\>"
 syn match cssColor contained "#[0-9A-Fa-f]\{3\}\>" contains=cssUnitDecorators
 syn match cssColor contained "#[0-9A-Fa-f]\{6\}\>" contains=cssUnitDecorators
 
-syn region cssURL contained matchgroup=cssFunctionName start="\<url\s*(" end=")" oneline
+syn region cssURL contained matchgroup=cssFunctionName start="\<url\s*(" end=")" oneline extend
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(rgb\|clip\|attr\|counter\|rect\|cubic-bezier\)\s*(" end=")" oneline  contains=cssValueInteger,cssValueNumber,cssValueLength,cssFunctionComma
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(rgba\|hsl\|hsla\|color-stop\|from\|to\)\s*(" end=")" oneline  contains=cssColor,cssValueInteger,cssValueNumber,cssValueLength,cssFunctionComma,cssFunction
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(linear-\|radial-\)\=\gradient\s*(" end=")" oneline  contains=cssColor,cssValueInteger,cssValueNumber,cssValueLength,cssFunction,cssGradientAttr,cssFunctionComma


### PR DESCRIPTION
A typical data encoded image in a `url()` group will start with
something like this:

```
data:image/svg+xml;base64,...
```

The `;` character wrecks havoc on `cssAttrRegion` because it closes the
group. Using `extend` on cssURL prevents the `;` from breaking out into
`cssAttrRegion` match and killing the rest of the syntax highlighting.
