### PR TITLE
Changed cssAttributeSelector to not be transparent

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -58,7 +58,7 @@ syn match cssTagName "\*"
 " selectors
 syn match cssSelectorOp "[,>+]"
 syn match cssSelectorOp2 "[~|^$*]\?=" contained
-syn region cssAttributeSelector matchgroup=cssSelectorOp start="\[" end="]" transparent contains=cssUnicodeEscape,cssSelectorOp2,cssStringQ,cssStringQQ
+syn region cssAttributeSelector matchgroup=cssSelectorOp start="\[" end="]" contains=cssUnicodeEscape,cssSelectorOp2,cssStringQ,cssStringQQ
 
 " .class and #id
 syn match cssClassName "\.[A-Za-z][A-Za-z0-9_-]\+"
@@ -534,6 +534,7 @@ if version >= 508 || !exists("did_css_syn_inits")
   HiLink cssUnicodeEscape Special
   HiLink cssStringQQ String
   HiLink cssStringQ String
+  HiLink cssAttributeSelector String
   HiLink cssMedia Special
   HiLink cssMediaType Special
   HiLink cssMediaComma Normal


### PR DESCRIPTION
It also inherits the String style, which I think is appropriate since
the syntax for it can be all over the place
