### PR TITLE
Tweaks to padding/border/content-box attribute

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -373,7 +373,7 @@ syn match cssTransitionAttr contained "\<step\(-start\|-end\)\=\>"
 " CSS Basic User Interface Module Level 3 (CSS3 UI)
 " http://www.w3.org/TR/css3-ui/
 syn match cssUIProp contained "\<box-sizing\>"
-syn match cssUIAttr contained "\<\(content\|padding\|border\)-box\>"
+syn match cssUIAttr contained "\<\(content\|padding\|border\)\(-box\)\=\>"
 
 syn keyword cssUIProp contained cursor
 syn match cssUIAttr contained "\<\(\([ns]\=[ew]\=\)\|col\|row\|nesw\|nwse\)-resize\>"


### PR DESCRIPTION
Apparently older versions of Firefox and current versions of webkit
support a sort of `alias` for padding/border/content-box which is
simplified without the -box.

This means that padding-box == padding, and content-box == content

For more info:
https://developer.mozilla.org/en-US/docs/Web/CSS/background-origin
