### PR TITLE
remove region definition for line comment

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -460,7 +460,6 @@ syn match cssPseudoClassId contained  "\<\(input-\)\=placeholder\>"
 
 " Comment
 syn region cssComment start="/\*" end="\*/" contains=@Spell
-syn region cssComment start="//" skip="\\$" end="$" keepend contains=@Spell
 
 syn match cssUnicodeEscape "\\\x\{1,6}\s\?"
 syn match cssSpecialCharQQ +\\"+ contained


### PR DESCRIPTION
`//` is not comment in [CSS 2.1](http://www.w3.org/TR/CSS21/syndata.html#comments) and also in [CSS3](http://www.w3.org/TR/css3-syntax/#comments).
