### PR TITLE
Recognize "\\" as css special char

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -458,8 +458,8 @@ syn match cssPseudoClassId contained  "\<\(input-\)\=placeholder\>"
 syn region cssComment start="/\*" end="\*/" contains=@Spell fold
 
 syn match cssUnicodeEscape "\\\x\{1,6}\s\?"
-syn match cssSpecialCharQQ +\\"+ contained
-syn match cssSpecialCharQ +\\'+ contained
+syn match cssSpecialCharQQ +\\\\\|\\"+ contained
+syn match cssSpecialCharQ +\\\\\|\\'+ contained
 syn region cssStringQQ start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=cssUnicodeEscape,cssSpecialCharQQ
 syn region cssStringQ start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=cssUnicodeEscape,cssSpecialCharQ
 


### PR DESCRIPTION
Currently, if you use something like

``` css
.breadcrumb:before { 
   content: "\\";
}
```

the syntax highlighting of the string is broken. The patch recognizes "\\" and displays it as a css special char.
