### PR TITLE
Adding image-rendering attributes and props

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -421,6 +421,10 @@ syn keyword cssUIAttr contained both horizontal vertical
 syn match cssUIProp contained "\<text-overflow\>"
 syn keyword cssUIAttr contained clip ellipsis
 
+syn match cssUIProp contained "\<image-rendering\>"
+syn keyword cssUIAttr contained pixellated
+syn match cssUIAttr contained "\<crisp-edges\>"
+
 " Already highlighted Props: font content
 "------------------------------------------------
 " Webkit/iOS specific attributes


### PR DESCRIPTION
As the title states, this adds the image-rendering attribute and related properties.

More info can be seen on [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering)