### PR TITLE
Add more relative length units

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -479,7 +479,7 @@ syn match cssPseudoClassId contained  "\<focus\(-inner\)\=\>"
 syn match cssPseudoClassId contained  "\<\(input-\)\=placeholder\>"
 
 " Misc highlight groups
-syntax match cssUnitDecorators /\(#\|-\|%\|mm\|cm\|in\|pt\|pc\|em\|ex\|px\|rem\|dpi\|dppx\|dpcm\|Hz\|kHz\|s\|ms\|deg\|grad\|rad\)/ contained
+syntax match cssUnitDecorators /\(#\|-\|%\|mm\|cm\|in\|pt\|pc\|em\|ex\|px\|ch\|rem\|vh\|vw\|vmin\|vmax\|dpi\|dppx\|dpcm\|Hz\|kHz\|s\|ms\|deg\|grad\|rad\)/ contained
 syntax match cssNoise contained /\(:\|;\|\/\)/
 
 " Comment


### PR DESCRIPTION
Adds support for the relative length units <code>ch</code>, <code>vh</code>, <code>vw</code>, <code>vmin</code>, and <code>vmax</code> (see https://developer.mozilla.org/en/docs/Web/CSS/length#Relative_length_units)